### PR TITLE
further improving performance

### DIFF
--- a/lib/grit/ref.rb
+++ b/lib/grit/ref.rb
@@ -23,8 +23,7 @@ module Grit
         refs = repo.git.refs(options, prefix)
         refs.split("\n").map do |ref|
           name, id = *ref.split(' ')
-          commit = Commit.create(repo, :id => id)
-          self.new(name, commit)
+          self.new(name, repo, id)
         end
       end
 
@@ -37,22 +36,34 @@ module Grit
     end
 
     attr_reader :name
-    attr_reader :commit
 
     # Instantiate a new Head
     #   +name+ is the name of the head
     #   +commit+ is the Commit that the head points to
     #
     # Returns Grit::Head (baked)
-    def initialize(name, commit)
+    def initialize(name, repo, commit_id)
       @name = name
-      @commit = commit
+      @commit_id = commit_id
+      @repo_ref = repo
+      @commit = nil
+    end
+
+    def commit
+      @commit ||= get_commit
     end
 
     # Pretty object inspection
     def inspect
       %Q{#<#{self.class.name} "#{@name}">}
     end
+
+    protected
+
+    def get_commit
+      Commit.create(@repo_ref, :id => @commit_id)
+    end
+
   end # Ref
 
   # A Head is a named reference to a Commit. Every Head instance contains a name
@@ -74,8 +85,7 @@ module Grit
       head = repo.git.fs_read('HEAD').chomp
       if /ref: refs\/heads\/(.*)/.match(head)
         id = repo.git.rev_parse(options, 'HEAD')
-        commit = Commit.create(repo, :id => id)
-        self.new($1, commit)
+        self.new($1, repo, id)
       end
     end
 

--- a/lib/grit/tag.rb
+++ b/lib/grit/tag.rb
@@ -7,17 +7,6 @@ module Grit
     lazy_reader :tagger
     lazy_reader :tag_date
 
-    def self.find_all(repo, options = {})
-      refs = repo.git.refs(options, prefix)
-      refs.split("\n").map do |ref|
-        name, id = *ref.split(' ')
-        sha = repo.git.commit_from_sha(id)
-        raise "Unknown object type." if sha == ''
-        commit = Commit.create(repo, :id => sha)
-        new(name, commit)
-      end
-    end
-
     # Writes a new tag object from a hash
     #  +repo+ is a Grit repo
     #  +hash+ is the hash of tag values
@@ -96,6 +85,12 @@ module Grit
         @tag_date = parsed[:tag_date]
       end
       self
+    end
+
+    def get_commit
+      sha = @repo_ref.git.commit_from_sha(@commit_id)
+      raise "Unknown object type." if sha == ''
+      Commit.create(@repo_ref, :id => sha)
     end
   end
 

--- a/test/test_remote.rb
+++ b/test/test_remote.rb
@@ -13,6 +13,6 @@ class TestRemote < Test::Unit::TestCase
   end
 
   def test_remote_count
-    assert_equal 4, @r.remote_count
+    assert_equal 7, @r.remote_count
   end
 end


### PR DESCRIPTION
Further related to gitlab issue https://github.com/gitlabhq/gitlabhq/issues/842 : the counting is now much faster, but listing all the branches and tags (for the dropdown select) is still slow.

So what did I do: instead of creating the commit for each tag we find, we store the commit-id instead, and only lookup the commit when we really need it. This speeds up the retrieval for showing in the select-box enormously. 

Also, this greatly speeds up things like `tags.count` and `tags.first`, effectively even rendering my previous change nearly unneeded.

Once this is merged, one only needs to update the `:ref` in the Gemfile to make the changes valid.
