### PR TITLE
force utf-8 encoding on object name

### DIFF
--- a/lib/grit/tree.rb
+++ b/lib/grit/tree.rb
@@ -93,7 +93,7 @@ module Grit
       if file =~ /\//
         file.split("/").inject(self) { |acc, x| acc/x } rescue nil
       else
-        self.contents.find { |c| c.name == file }
+        self.contents.find { |c| c.name.force_encoding("UTF-8") == file }
       end
     end
 


### PR DESCRIPTION
Forces object name to utf-8 to support some more exotic characters.

Fixes:
gitlabhq/gitlabhq#175
gitlabhq/gitlabhq#473
