### PR TITLE
support ruby 2.0

### DIFF
--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -14,7 +14,7 @@ require 'grit/git-ruby/internal/raw_object'
 require 'grit/git-ruby/internal/file_window'
 
 PACK_SIGNATURE = "PACK"
-PACK_IDX_SIGNATURE = "\377tOc"
+PACK_IDX_SIGNATURE = "\377tOc".b
 
 module Grit
   module GitRuby

--- a/lib/grit/ruby1.9.rb
+++ b/lib/grit/ruby1.9.rb
@@ -4,4 +4,12 @@ class String
   else
     alias :getord :[]
   end
+
+  unless self.method_defined?(:b)
+    if self.method_defined?(:force_encoding)
+      def b; self.dup.force_encoding(Encoding::ASCII_8BIT); end
+    else
+      def b; self.dup; end
+    end
+  end
 end


### PR DESCRIPTION
Hello,

Current grit does not work because 
- version checking condition does not work for ruby-2.0.
- PACK_IDX_SIGNATURE string is treated as UTF-8 in ruby 2.0.

I confirmed that tests still pass on ruby 1.9.3p392 and on ruby 2.0.0p0 with this change. FYI to run tests on ruby 2.0.0p0 we also need to modify mocha like https://github.com/freerange/mocha/commit/cf91bded89fe2172f2f82146aaacaa520f564b0 .

Kazuhiko
