### PR TITLE
update mocha to support tests on ruby 2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ group :development, :test do
   gem 'posix-spawn', "~> 0.3.6"
   gem 'mime-types', "~> 1.15"
   gem 'diff-lcs', "~> 1.1"
-  gem 'mocha'
+  gem 'mocha', "~> 0.13.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     diff-lcs (1.1.3)
     metaclass (0.0.1)
     mime-types (1.18)
-    mocha (0.11.4)
+    mocha (0.13.2)
       metaclass (~> 0.0.1)
     posix-spawn (0.3.6)
     rake (0.9.2.2)
@@ -15,6 +15,6 @@ PLATFORMS
 DEPENDENCIES
   diff-lcs (~> 1.1)
   mime-types (~> 1.15)
-  mocha
+  mocha (~> 0.13.2)
   posix-spawn (~> 0.3.6)
   rake


### PR DESCRIPTION
Now ruby 2.0.0 is added to travis for gitlabhq/grit, but we need to use newer mocha (>= 0.13.2) to run grit tests on ruby 2.0.
