### PR TITLE
Fix invalid byte sequence errors when using grep method

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -715,7 +715,7 @@ module Grit
 
     def grep(searchtext, contextlines = 3, branch = 'master')
       context_arg = '-C ' + contextlines.to_s
-      result = git.native(:grep, {}, '-n', '-E', '-i', '-z', '--heading', '--break', context_arg, searchtext, branch).force_encoding('UTF-8')
+      result = git.native(:grep, {}, '-n', '-E', '-i', '-z', '--heading', '--break', context_arg, searchtext, branch).encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
       greps = []
       filematches = result.split("\n\n")
       filematches.each do |filematch|


### PR DESCRIPTION
When using code search, errors are throw of Invalid byte sequence

This fixes that by converting the encoding correctly to UTF8
