### PR TITLE
git 1.7.4.6 required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This documentation is accurate as of Grit 2.3.
 
 ## Requirements
 
-* git (http://git-scm.com) tested with 1.7.2.1
+* git (http://git-scm.com) tested with 1.7.4.6
 
 
 ## Install


### PR DESCRIPTION
The following tests failed with git 1.7.2.1
- grit/test/test_commit.rb:201
- grit/test/test_repo.rb:422

The minimum version passing tests was 1.7.4.6

Environment:
- Ubuntu 10.04.3 LTS Desktop x86_64
- Compile git from source (github.com/git/git)
