### PR TITLE
Get blob path (eg. @blob.path = 'lib/grit/blob.rb')

### DIFF
--- a/lib/grit/blob.rb
+++ b/lib/grit/blob.rb
@@ -29,6 +29,22 @@ module Grit
       self
     end
 
+    # The repo object of this blob
+    #
+    # Returning Grit::Repo
+    def repo
+      @repo
+    end
+
+    # The path of this blob ( eg. lib/grit/blob.rb )
+    #   +treeish+ is the Commit
+    #
+    # Returns String
+    def path(treeish = 'master')
+      revs = @repo.git.native(:ls_tree, {:r => true}, treeish, "| grep #{@id}")
+      path = revs.split("\n").first.to_s.split("\t").last
+    end
+
     # The size of this blob in bytes
     #
     # Returns Integer


### PR DESCRIPTION
I add instance method to get path of blob and tree (and also add method to get repo)
# Usage
### Blob

You can get current blob path with `@blob.path` ( default is master branch)

``` ruby
repo = Grit::Repo.new(".")
@blob = repo.tree/"lib/grit/blob.rb"
@blob.path
#=> "lib/grit/blob.rb"
```

And you can also set specific commit like this

``` ruby
repo = Grit::Repo.new(".")
commit = repo.commits.first
@blob = commit.tree/"lib/grit/blob.rb"
@blob.path(commit) 
#=> "lib/grit/blob.rb"
```
