### PR TITLE
Fix returning wrong blob id bug in repo.diff(a, b, *paths)

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -564,7 +564,7 @@ module Grit
     #   +b+ is the other commit
     #   +paths+ is an optional list of file paths on which to restrict the diff
     def diff(a, b, *paths)
-      diff = self.git.native('diff', {}, a, b, '--', *paths)
+      diff = self.git.native('diff', {:full_index => true}, a, b, '--', *paths)
 
       if diff =~ /diff --git a/
         diff = diff.sub(/.*?(diff --git a)/m, '\1')


### PR DESCRIPTION
### Bug

Return wrong blob object when `repo.diff` like this

``` ruby
repo = Grit::Repo.new(".")
head = repo.commits.first
base = repo.commits.last

blob = repo.diff(base, head).first.b_blob
# => #<Grit::Blob "0218f96"> 
```
### Fix

Return wrong blob object when `repo.diff` like this

``` ruby
repo = Grit::Repo.new(".")
head = repo.commits.first
base = repo.commits.last

blob = repo.diff(base, head).first.b_blob
=> #<Grit::Blob "00dd8a636fd79e9436f792cac68f9d2dd3708399"> 
```
