### PR TITLE
Fixed issue #27 - Changed split to be regexp instead of string

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -721,7 +721,7 @@ module Grit
       filematches.each do |filematch|
         binary = false
         file = ''
-        matches = filematch.split("--\n")
+        matches = filematch.split(/^--\n/)
         matches.each_with_index do |match, i|
           content = []
           startline = 0


### PR DESCRIPTION
Added /^--\n/ to line 724 instead of "--\n"

This caused errors, when in the file to be grepped a "--\n" string was present as in markdown files used for Headings
