### PR TITLE
Fixed issue #32 - Error requiring grit

### DIFF
--- a/gitlab-grit.gemspec
+++ b/gitlab-grit.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE]
-  s.files = `git ls-files lib/`.split("\n")
+  s.files = `git ls-files lib/`.split("\n") << 'VERSION'
   s.test_files = s.files.select { |path| path =~ /^test\/test_.*\.rb/ }
 
   s.add_dependency("charlock_holmes", "~> 0.6.9")

--- a/lib/grit.rb
+++ b/lib/grit.rb
@@ -50,7 +50,7 @@ require 'grit/merge'
 require 'grit/grep'
 
 module Grit
-  VERSION = File.read("VERSION").strip
+  VERSION = File.read(File.expand_path("../../VERSION", __FILE__)).chomp.strip
 
   class << self
     # Set +debug+ to true to log all git calls and responses


### PR DESCRIPTION
This patch includes `VERSION` file to the gem file to avoid the error when this gem is required.

https://github.com/gitlabhq/grit/issues/32
