### PR TITLE
fix grep while it matches in binary files

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -718,11 +718,13 @@ module Grit
       context_arg = '-C ' + contextlines.to_s
       result = git.native(:grep, {pipeline: false}, '-n', '-E', '-i', '-z', '--heading', '--break', context_arg, searchtext, branch).encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
       greps = []
+      result.gsub!(/(^Binary file (.+) matches$)/, "\n\\1\n")
+      result.strip!
       filematches = result.split("\n\n")
       filematches.each do |filematch|
         binary = false
         file = ''
-        matches = filematch.split("--\n")
+        matches = filematch.strip.split("--\n")
         matches.each_with_index do |match, i|
           content = []
           startline = 0
@@ -733,10 +735,10 @@ module Grit
             file = text[/^Binary file (.+) matches$/]
             if file
               binary = true
-            else
-              text.slice! /^#{branch}:/
-              file = text
+              text = $1
             end
+            text.slice! /^#{branch}:/
+            file = text
           end
           lines.each_with_index do |line, j|
             line.chomp!

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -424,4 +424,21 @@ class TestRepo < Test::Unit::TestCase
     assert_equal 'test/test_repo.rb', res.first.filename
     assert_equal '  def test_select_existing_objects', res.first.content[1]
   end
+
+  def test_grep_binary
+    res = @r.grep('origin/HEAD', 1, 'master')
+    assert_equal 5, res.length
+
+    assert_equal 874, res.first.startline
+    assert_equal 'test/dot_git/file-index', res.first.filename
+    assert_equal 'test/dot_git/refs/remotes/origin/HEAD', res.first.content[1]
+
+    assert_equal 0, res[1].startline
+    assert_equal 'test/dot_git/index', res[1].filename
+    assert_equal [], res[1].content
+
+    assert_equal 5, res[3].startline
+    assert_equal 'test/dot_git_iv2/info/refs', res[3].filename
+    assert_equal "ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a\trefs/remotes/origin/HEAD", res[3].content[1]
+  end
 end


### PR DESCRIPTION
Sometimes there is no "\n\n" between "Binary file ... matches" and the others.

```
master:test/dot_git/file-index
874^@test/dot_git/refs/heads/master
875^@test/dot_git/refs/remotes/origin/HEAD
876^@test/dot_git/refs/remotes/origin/master
Binary file master:test/dot_git/index matches
Binary file master:test/dot_git_iv2/index matches
master:test/dot_git_iv2/info/refs
5^@2d3acf90f35989df8f262dc50beadc4ee3ae1560     refs/heads/testing
6^@ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a     refs/remotes/origin/HEAD
7^@ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a     refs/remotes/origin/master
```

The gitlab search snapshots:

before

![2014-03-07 12 24 07](https://f.cloud.github.com/assets/459733/2347966/a06766aa-a552-11e3-9621-7a6dc36064fb.png)

after

![2014-03-07 1 11 24](https://f.cloud.github.com/assets/459733/2347967/a64bf504-a552-11e3-930e-e6bf72a25976.png)

/cc @jacargentina
