### PR TITLE
Fix spawn of compress_cmd hang

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -600,9 +600,9 @@ module Grit
       open(filename, 'w') do |file|
         pipe_rd, pipe_wr = IO.pipe
         git_archive_pid = spawn(*git_archive_cmd, :out => pipe_wr)
+        pipe_wr.close
         compress_pid = spawn(*compress_cmd, :in => pipe_rd, :out => file)
         pipe_rd.close
-        pipe_wr.close
         Process.waitpid(git_archive_pid)
         Process.waitpid(compress_pid)
       end


### PR DESCRIPTION
Spawn of compress_cmd hangs if pipe_wr is not closed before spawning.
Should fix: gitlabhq/gitlabhq#6922

This bug hits the download as archive function.
It makes the website hang when trying to download an archive and can create empty tar.gz files.
