### PR TITLE
update(gems): update mime-types gem to 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development, :test do
   gem 'pry'
   gem 'rake'
   gem 'posix-spawn', "~> 0.3.6"
-  gem 'mime-types', "~> 1.15"
+  gem 'mime-types', "~> 2.6"
   gem 'diff-lcs', "~> 1.1"
   gem 'mocha', "~> 0.13.2"
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     gitlab-grit (2.7.3)
       charlock_holmes (~> 0.6)
       diff-lcs (~> 1.1)
-      mime-types (~> 1.15)
+      mime-types (~> 2.6)
       posix-spawn (~> 0.3)
 
 GEM
@@ -56,7 +56,7 @@ DEPENDENCIES
   coveralls
   diff-lcs (~> 1.1)
   gitlab-grit!
-  mime-types (~> 1.15)
+  mime-types (~> 2.6)
   mocha (~> 0.13.2)
   posix-spawn (~> 0.3.6)
   pry

--- a/gitlab-grit.gemspec
+++ b/gitlab-grit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("charlock_holmes", "~> 0.6")
   s.add_dependency('posix-spawn', "~> 0.3")
-  s.add_dependency('mime-types', "~> 1.15")
+  s.add_dependency('mime-types', "~> 2.6")
   s.add_dependency('diff-lcs', "~> 1.1")
   s.add_development_dependency('mocha')
 end


### PR DESCRIPTION
I use gollum with `gollum-rugged_adapter` and `mime-types` ~>2.6 is a requirement

I upgrade this requirement into this repo. Hope it's valid and ok for you.

Thanks
/Richard